### PR TITLE
Issue, Tests & possible bugfix for EasyDb::is1DArray()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/tests/phpunit.phar
+/tests/phpunit.phar.asc

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -731,6 +731,9 @@ class EasyDB
      */
     public function is1DArray(array $params)
     {
-        return \count($params) === \count($params, COUNT_RECURSIVE);
+        return (
+            \count($params) === \count($params, COUNT_RECURSIVE) &&
+            \count(\array_filter($params, 'is_array')) < 1
+        );
     }
 }

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -731,6 +731,6 @@ class EasyDB
      */
     public function is1DArray(array $params)
     {
-        return \count($params) !== \count($params, COUNT_RECURSIVE);
+        return \count($params) === \count($params, COUNT_RECURSIVE);
     }
 }

--- a/tests/phpunit.sh
+++ b/tests/phpunit.sh
@@ -36,7 +36,7 @@ if [ $? -eq 0 ]; then
     echo
     echo -e "\033[33mBegin Unit Testing\033[0m"
     # Run the testing suite
-    php phpunit.phar --bootstrap ../vendor/autoload.php unit
+    php phpunit.phar --bootstrap ../vendor/autoload.php ./unit
     # Cleanup
     if [ "$clean" -eq 1 ]; then
         echo -e "\033[32mCleaning Up!\033[0m"

--- a/tests/unit.php
+++ b/tests/unit.php
@@ -1,0 +1,31 @@
+<?php
+namespace ParagonIE\EasyDB;
+
+use PHPUnit_Framework_TestCase;
+
+require_once('../vendor/autoload.php');
+
+class unit
+    extends
+        PHPUnit_Framework_TestCase
+{
+
+
+    public function EasyDBProvider() : array
+    {
+        return [
+            [
+                Factory::create('sqlite::memory:')
+            ],
+        ];
+    }
+
+    /**
+    * @dataProvider EasyDBProvider
+    */
+    public function testIs1DArray(EasyDB $db)
+    {
+        $this->assertTrue($db->is1DArray([]));
+        $this->assertFalse($db->is1DArray([[]]));
+    }
+}

--- a/tests/unit.php
+++ b/tests/unit.php
@@ -27,5 +27,9 @@ class unit
     {
         $this->assertTrue($db->is1DArray([]));
         $this->assertFalse($db->is1DArray([[]]));
+        $this->assertFalse($db->is1DArray([[],[]]));
+        $this->assertTrue($db->is1DArray([1]));
+        $this->assertFalse($db->is1DArray([[1]]));
+        $this->assertFalse($db->is1DArray([[1],[2]]));
     }
 }


### PR DESCRIPTION
Currently using easydb at work, noticed a couple of issues when passing arguments in: if passing an empty array, EasyDB::is1DArray() returned false.

Not 100% sure, but I've tinkered with the method & added  phpunit tests for checking this method (this in no way satisfies issue #1, it's just to demonstrate the bug & fix).

For a point of reference, here's the output of `php --version`:
> PHP 7.0.9 (cli) (built: Jul 20 2016 11:08:23) ( ZTS )
Copyright (c) 1997-2016 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies