### PR TITLE
sqlite driver complains of extraneous parameters

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -61,7 +61,6 @@ class EasyDB
         $exec = $stmt->execute($params);
         if ($exec) {
             return $stmt->fetchAll(
-                \PDO::FETCH_ASSOC,
                 \PDO::FETCH_COLUMN,
                 $offset
             );


### PR DESCRIPTION
Currently only testing with the sqlite driver, but [going by the manual](http://php.net/manual/en/pdostatement.fetchall.php), we only need two parameters here.

Compare travis output:
- [before](https://travis-ci.org/SignpostMarv/easydb/jobs/167899952)
- [after](https://travis-ci.org/SignpostMarv/easydb/jobs/167900635)