### PR TITLE
Bugfix tests for 2.x, as promised

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ before_script:
   - composer install
 script:
   - composer run tests
+matrix:
+  allow_failures:
+    - php: hhvm

--- a/phpunit.sh
+++ b/phpunit.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 clean=1 # Clean up?
+function cleanupPhpUnit
+{
+  # Cleanup
+  if [ "$clean" -eq 1 ]; then
+      echo -e "\033[32mCleaning Up!\033[0m"
+      rm -f phpunit.phar
+      rm -f phpunit.phar.asc
+  fi
+}
 gpg --fingerprint D8406D0D82947747293778314AA394086372C20A
 if [ $? -ne 0 ]; then
     echo -e "\033[33mDownloading PGP Public Key...\033[0m"
@@ -38,15 +47,18 @@ if [ $? -eq 0 ]; then
     # Run the testing suite
     if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ]; then
       echo 'xdebug.enable = On' >> /etc/hhvm/php.ini;
-      hhvm -v Eval.EnableHipHopSyntax=true phpunit.phar --verbose
+      if hhvm -v Eval.EnableHipHopSyntax=true phpunit.phar --verbose; then
+        cleanupPhpUnit;
+      else
+        echo "build fa" 1>&2
+        exit 1
+      fi
     else
-      php phpunit.phar --verbose
-    fi
-    # Cleanup
-    if [ "$clean" -eq 1 ]; then
-        echo -e "\033[32mCleaning Up!\033[0m"
-        rm -f phpunit.phar
-        rm -f phpunit.phar.asc
+      if php phpunit.phar --verbose; then
+        cleanupPhpUnit;
+      else
+        exit 1
+      fi
     fi
 else
     echo

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -498,6 +498,15 @@ class EasyDB
      */
     public function insertMany(string $table, array $maps): int
     {
+        if (count($maps) < 1) {
+            throw new \InvalidArgumentException(
+                'Argument 2 passed to ' .
+                static::class .
+                '::' .
+                __METHOD__ .
+                '() must contain at least one field set!'
+            );
+        }
         $first = $maps[0];
         foreach ($maps as $map) {
             if (!$this->is1DArray($map)) {

--- a/tests/EscapeIdentifierTest.php
+++ b/tests/EscapeIdentifierTest.php
@@ -25,8 +25,6 @@ class EscapeIdentifierTest
             'foo',
             'foo1',
             'foo_2',
-            'foo 3',
-            'foo-4',
         ];
         return array_reduce(
             $this->GoodFactoryCreateArgument2EasyDBProvider(),
@@ -55,6 +53,8 @@ class EscapeIdentifierTest
         $identifiers = [
             1,
                 '2foo',
+            'foo 3',
+            'foo-4',
             null,
             false,
             []

--- a/tests/EscapeIdentifierTest.php
+++ b/tests/EscapeIdentifierTest.php
@@ -52,7 +52,7 @@ class EscapeIdentifierTest
     {
         $identifiers = [
             1,
-                '2foo',
+            '2foo',
             'foo 3',
             'foo-4',
             null,

--- a/tests/InsertManyTest.php
+++ b/tests/InsertManyTest.php
@@ -18,7 +18,7 @@ class InsertManyTest
     public function testInsertManyNoFieldsThrowsException(callable $cb)
     {
         $db = $this->EasyDBExpectedFromCallable($cb);
-        $this->expectException(PDOException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->assertFalse($db->insertMany('irrelevant_but_valid_tablename', []));
     }
 

--- a/tests/InsertManyTest.php
+++ b/tests/InsertManyTest.php
@@ -15,10 +15,10 @@ class InsertManyTest
     /**
     * @dataProvider GoodFactoryCreateArgument2EasyDBProvider
     */
-    public function testInsertManyReturnsNull(callable $cb)
+    public function testInsertManyNoFieldsThrowsException(callable $cb)
     {
         $db = $this->EasyDBExpectedFromCallable($cb);
-
+        $this->expectException(PDOException::class);
         $this->assertFalse($db->insertMany('irrelevant_but_valid_tablename', []));
     }
 

--- a/tests/InsertManyTest.php
+++ b/tests/InsertManyTest.php
@@ -25,10 +25,10 @@ class InsertManyTest
     /**
     * @dataProvider GoodFactoryCreateArgument2EasyDBProvider
     */
-    public function testInsertManyThrowsException(callable $cb)
+    public function testInsertManyNoFieldsThrowsPdoException(callable $cb)
     {
         $db = $this->EasyDBExpectedFromCallable($cb);
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(PDOException::class);
         $db->insertMany('irrelevant_but_valid_tablename', [[], [1]]);
     }
 

--- a/tests/InsertTest.php
+++ b/tests/InsertTest.php
@@ -15,10 +15,10 @@ class InsertTest
     /**
     * @dataProvider GoodFactoryCreateArgument2EasyDBProvider
     */
-    public function testInsertReturnsNull(callable $cb)
+    public function testInsertNoFieldsThrowsException(callable $cb)
     {
         $db = $this->EasyDBExpectedFromCallable($cb);
-
+        $this->expectException(PDOException::class);
         $this->assertNull($db->insert('irrelevant_but_valid_tablename', []));
     }
 

--- a/tests/SetAttributeTest.php
+++ b/tests/SetAttributeTest.php
@@ -135,6 +135,12 @@ class SetAttributeTest
                 Exception::class,
                 'EasyDB does not allow the use of emulated prepared statements, which would be a security downgrade.',
             ],
+            [
+                PDO::ATTR_EMULATE_PREPARES,
+                1,
+                Exception::class,
+                '!EasyDB does not allow the use of emulated prepared statements, which would be a security downgrade.',
+            ],
         ];
         return array_reduce(
             $this->GoodFactoryCreateArgument2EasyDBProvider(),

--- a/tests/SetAttributeTest.php
+++ b/tests/SetAttributeTest.php
@@ -139,7 +139,7 @@ class SetAttributeTest
                 PDO::ATTR_EMULATE_PREPARES,
                 1,
                 Exception::class,
-                '!EasyDB does not allow the use of emulated prepared statements, which would be a security downgrade.',
+                'EasyDB does not allow the use of emulated prepared statements, which would be a security downgrade.',
             ],
         ];
         return array_reduce(

--- a/tests/SetAttributeTest.php
+++ b/tests/SetAttributeTest.php
@@ -3,6 +3,7 @@ declare (strict_types=1);
 
 namespace ParagonIE\EasyDB\Tests;
 
+use Exception;
 use ParagonIE\EasyDB\EasyDB;
 use PDO;
 use PDOException;
@@ -76,6 +77,30 @@ class SetAttributeTest
                     ' as driver "' .
                     $db->getDriver() .
                     '" does not support that attribute'
+                );
+            } else {
+                throw $e;
+            }
+        } catch (Exception $e) {
+            if (
+                (
+                    $attrName === 'ATTR_ERRMODE' &&
+                    $e->getMessage() === 'EasyDB only allows the safest-by-default error mode (exceptions).'
+                ) ||
+                (
+                    $attrName === 'ATTR_EMULATE_PREPARES' &&
+                    $e->getMessage() === 'EasyDB does not allow the use of emulated prepared statements, which would be a security downgrade.'
+                )
+            ) {
+                $this->markTestSkipped(
+                    'Skipping tests for ' .
+                    EasyDB::class .
+                    '::setAttribute() with ' .
+                    PDO::class .
+                    '::' .
+                    $attrName .
+                    ' as ' .
+                    $e->getMessage()
                 );
             } else {
                 throw $e;

--- a/tests/SingleTestThenExistsTest.php
+++ b/tests/SingleTestThenExistsTest.php
@@ -1,0 +1,62 @@
+<?php
+declare (strict_types=1);
+
+namespace ParagonIE\EasyDB\Tests;
+
+use ParagonIE\EasyDB\EasyDB;
+
+class SingleTestThenExistsTest
+    extends
+        EasyDBWriteTest
+{
+
+
+    protected function getResultForMethod(EasyDB $db, $statement, $params)
+    {
+        $args = $params;
+        array_unshift($args, $statement);
+        return call_user_func_array([$db, 'exists'], $args);
+    }
+
+    /**
+    * @dataProvider GoodFactoryCreateArgument2EasyDBInsertManyProvider
+    * @depends ParagonIE\EasyDB\Tests\Is1DArrayThenDeleteReadOnlyTest::testDeleteThrowsException
+    * @depends ParagonIE\EasyDB\Tests\Is1DArrayThenDeleteReadOnlyTest::testDeleteTableNameEmptyThrowsException
+    * @depends ParagonIE\EasyDB\Tests\Is1DArrayThenDeleteReadOnlyTest::testDeleteTableNameInvalidThrowsException
+    * @depends ParagonIE\EasyDB\Tests\Is1DArrayThenDeleteReadOnlyTest::testDeleteConditionsReturnsNull
+    * @depends ParagonIE\EasyDB\Tests\InsertManyTest::testInsertMany
+    * @depends ParagonIE\EasyDB\Tests\SingleTest::testMethod
+    */
+    public function testExists(callable $cb, array $insertMany)
+    {
+        $db = $this->EasyDBExpectedFromCallable($cb);
+        $this->assertFalse(
+            $db->exists('SELECT COUNT(*) FROM irrelevant_but_valid_tablename')
+        );
+        $db->insertMany('irrelevant_but_valid_tablename', $insertMany);
+        $insertManyTotal = count($insertMany);
+        $this->assertTrue(
+            $db->exists('SELECT COUNT(*) FROM irrelevant_but_valid_tablename')
+        );
+        foreach ($insertMany as $insertVal) {
+            $this->assertTrue(
+                $this->getResultForMethod(
+                    $db,
+                    'SELECT COUNT(*) FROM irrelevant_but_valid_tablename WHERE foo = ?',
+                    array_values($insertVal)
+                )
+            );
+            $db->delete('irrelevant_but_valid_tablename', $insertVal);
+            $this->assertFalse(
+                $this->getResultForMethod(
+                    $db,
+                    'SELECT COUNT(*) FROM irrelevant_but_valid_tablename WHERE foo = ?',
+                    array_values($insertVal)
+                )
+            );
+        }
+        $this->assertFalse(
+            $db->exists('SELECT COUNT(*) FROM irrelevant_but_valid_tablename')
+        );
+    }
+}


### PR DESCRIPTION
- Fixed some bugs in the tests (new return types, change in behaviour etc.) 2503eeca45ba061f64550bb897e5d61904490ef4...dd32e4a7c97fb504d9c788a8b2a3aab0ec9a5736
 - dd32e4a7c97fb504d9c788a8b2a3aab0ec9a5736 probably renders moot the todo I left myself in 968270c3e6d42887d928c52b8af80d44fe7a1729
- Made travis builds fail if phpunit tests fail dd32e4a7c97fb504d9c788a8b2a3aab0ec9a5736...4b9a77de2ea42dcc24af80d36dc1c376320844c0
 - [proof-of-concept for 7229375](https://travis-ci.org/SignpostMarv/easydb/builds/168990728)
 - [build fails despite passing on php/nightly](https://travis-ci.org/SignpostMarv/easydb/builds/168991774)
 - [allowing build to pass despite failure due to hhvm/phpunit not playing nice](https://travis-ci.org/SignpostMarv/easydb/builds/168992887)
- added coverage for methods added in 2.x 4b9a77de2ea42dcc24af80d36dc1c376320844c0...ef804da02d096b50a6fcbb0719d6bc899a71040c