### PR TITLE
Add EasyStatement query condition builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.1.0
+
+* Add `EasySatement` condition builder, thanks [@shadowhand](https://github.com/shadowhand)
+
 # Version 0.2.0
 
 * Optimized `EasyDB::column()` thanks [@Xeoncross](https://github.com/Xeoncross)

--- a/README.md
+++ b/README.md
@@ -119,13 +119,72 @@ $exists = $db->single(
 );
 ```
 
-### What if I need PDO for something specific?
+### Generate dynamic query conditions
+
+```php
+$statement = EasyStatement::open()
+    ->andWith('last_login IS NOT NULL');
+
+if (strpos($_POST['search'], '@') !== false) {
+    // Perform a username search
+    $statement->orWith('username LIKE ?', '%' . $_POST['search'] . '%');
+} else {
+    // Perform an email search
+    $statement->orWith('email = ?', $_POST['search']);
+}
+
+// The statement can compile itself to a string with placeholders:
+echo $statement; /* last_login IS NOT NULL OR username LIKE ? */
+
+// All the values passed to the statement are captured and can be used for querying:
+$user = $db->single("SELECT * FROM users WHERE $statement", $statement->values());
+```
+
+_**Note**: Passing values with conditions is entirely optional but recommended._
+
+#### Variable number of "IN" arguments
+
+```php
+// Statements also handle translation for IN conditions with variable arguments,
+// using a special ?* placeholder:
+$roles = [1];
+if ($_GET['with_managers']) {
+    $roles[] = 2;
+}
+
+$statement = EasyStatement::open()->andIn('role IN (?*)', $roles);
+
+// The ?* placeholder is replaced by the correct number of ? placeholders:
+echo $statement; /* role IN (?, ?) */
+
+// And the values will be unpacked accordingly:
+print_r($statement->values()); /* [1, 2] */
+```
+
+#### Grouping of conditions
+
+```php
+// Statements can also be grouped when necessary:
+$statement = EasyStatement::open()
+    ->andGroup()
+        ->andWith('subtotal > ?')
+        ->andWith('taxes > ?')
+    ->endGroup()
+    ->orGroup()
+        ->andWith('cost > ?')
+        ->andWith('cancelled = 1')
+    ->endGroup();
+
+echo $statement; /* (subtotal > ? AND taxes > ?) OR (cost > ? AND cancelled = 1) */
+```
+
+## What if I need PDO for something specific?
 
 ```php
 $pdo = $db->getPdo();
 ```
 
-### Can I create an EasyDB wrapper for an existing PDO instance?
+## Can I create an EasyDB wrapper for an existing PDO instance?
 
 **Yes!** It's as simple as doing this:
 
@@ -133,7 +192,7 @@ $pdo = $db->getPdo();
 $easy = new \ParagonIE\EasyDB\EasyDB($pdo, 'mysql');
 ```
 
-### How do I run tests ?
+## How do I run tests ?
 
 ```sh
 composer run tests

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $exists = $db->single(
 
 ```php
 $statement = EasyStatement::open()
-    ->andWith('last_login IS NOT NULL');
+    ->with('last_login IS NOT NULL');
 
 if (strpos($_POST['search'], '@') !== false) {
     // Perform a username search
@@ -152,7 +152,7 @@ if ($_GET['with_managers']) {
     $roles[] = 2;
 }
 
-$statement = EasyStatement::open()->andIn('role IN (?*)', $roles);
+$statement = EasyStatement::open()->in('role IN (?*)', $roles);
 
 // The ?* placeholder is replaced by the correct number of ? placeholders:
 echo $statement; /* role IN (?, ?) */
@@ -166,14 +166,14 @@ print_r($statement->values()); /* [1, 2] */
 ```php
 // Statements can also be grouped when necessary:
 $statement = EasyStatement::open()
-    ->andGroup()
-        ->andWith('subtotal > ?')
+    ->group()
+        ->with('subtotal > ?')
         ->andWith('taxes > ?')
-    ->endGroup()
+    ->end()
     ->orGroup()
-        ->andWith('cost > ?')
+        ->with('cost > ?')
         ->andWith('cancelled = 1')
-    ->endGroup();
+    ->end();
 
 echo $statement; /* (subtotal > ? AND taxes > ?) OR (cost > ? AND cancelled = 1) */
 ```

--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -17,6 +17,19 @@ class EasyStatement
     }
 
     /**
+     * Alias for andWith().
+     *
+     * @param string $condition
+     * @param mixed $values, ...
+     *
+     * @return self
+     */
+    public function with($condition, ...$values)
+    {
+        return $this->andWith($condition, ...$values);
+    }
+
+    /**
      * Add a condition that will be applied with a logical "AND".
      *
      * @param string $condition
@@ -55,6 +68,19 @@ class EasyStatement
     }
 
     /**
+     * Alias for andIn().
+     *
+     * @param string $condition
+     * @param array $values
+     *
+     * @return self
+     */
+    public function in($condition, array $values)
+    {
+        return $this->andIn($condition, $values);
+    }
+
+    /**
      * Add an IN condition that will be applied with a logical "AND".
      *
      * Instead of using ? to denote the placeholder, ?* must be used!
@@ -82,6 +108,16 @@ class EasyStatement
     public function orIn($condition, array $values)
     {
         return $this->orWith($this->unpackCondition($condition, \count($values)), ...$values);
+    }
+
+    /**
+     * Alias for andGroup().
+     *
+     * @return static
+     */
+    public function group()
+    {
+        return $this->andGroup();
     }
 
     /**
@@ -120,6 +156,16 @@ class EasyStatement
         ];
 
         return $group;
+    }
+
+    /**
+     * Alias for endGroup().
+     *
+     * @return static
+     */
+    public function end()
+    {
+        return $this->endGroup();
     }
 
     /**

--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace ParagonIE\EasyDB;
+
+use RuntimeException;
+
+class EasyStatement
+{
+    /**
+     * Open a new statement.
+     *
+     * @return static
+     */
+    public static function open()
+    {
+        return new static();
+    }
+
+    /**
+     * Add a condition that will be applied with a logical "AND".
+     *
+     * @param string $condition
+     * @param ... $values
+     *
+     * @return self
+     */
+    public function andWith($condition, ...$values)
+    {
+        $this->parts[] = [
+            'type' => 'AND',
+            'condition' => $condition,
+            'values' => $values,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Add a condition that will be applied with a logical "OR".
+     *
+     * @param string $condition
+     * @param ... $values
+     *
+     * @return self
+     */
+    public function orWith($condition, ...$values)
+    {
+        $this->parts[] = [
+            'type' => 'OR',
+            'condition' => $condition,
+            'values' => $values,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Add an IN condition that will be applied with a logical "AND".
+     *
+     * Instead of using ? to denote the placeholder, ?* must be used!
+     *
+     * @param string $condition
+     * @param array $values
+     *
+     * @return self
+     */
+    public function andIn($condition, array $values)
+    {
+        return $this->andWith($this->unpackCondition($condition, \count($values)), ...$values);
+    }
+
+    /**
+     * Add an IN condition that will be applied with a logical "OR".
+     *
+     * Instead of using "?" to denote the placeholder, "?*" must be used!
+     *
+     * @param string $condition
+     * @param array $values
+     *
+     * @return self
+     */
+    public function orIn($condition, array $values)
+    {
+        return $this->orWith($this->unpackCondition($condition, \count($values)), ...$values);
+    }
+
+    /**
+     * Start a new grouping that will be applied with a logical "AND".
+     *
+     * Exit the group with endGroup().
+     *
+     * @return static
+     */
+    public function andGroup()
+    {
+        $group = new self($this);
+
+        $this->parts[] = [
+            'type' => 'AND',
+            'condition' => $group,
+        ];
+
+        return $group;
+    }
+
+    /**
+     * Start a new grouping that will be applied with a logical "OR".
+     *
+     * Exit the group with endGroup().
+     *
+     * @return static
+     */
+    public function orGroup()
+    {
+        $group = new self($this);
+
+        $this->parts[] = [
+            'type' => 'OR',
+            'condition' => $group,
+        ];
+
+        return $group;
+    }
+
+    /**
+     * Exit the current grouping and return the parent statement.
+     *
+     * @return static
+     *
+     * @throws RuntimeException
+     *  If the current statement has no parent context.
+     */
+    public function endGroup()
+    {
+        if (empty($this->parent)) {
+            throw new RuntimeException('Already at the top of the statement');
+        }
+
+        return $this->parent;
+    }
+
+    /**
+     * Compile the current statement into PDO-ready SQL.
+     *
+     * @return string
+     */
+    public function sql()
+    {
+        return \array_reduce($this->parts, function ($sql, $part) {
+            if ($this->isGroup($part['condition'])) {
+                // (...)
+                $statement = '(' . $part['condition']->sql() . ')';
+            } else {
+                // foo = ?
+                $statement = $part['condition'];
+            }
+
+            if ($sql) {
+                // AND|OR ...
+                $statement = $part['type'] . ' ' . $statement;
+            }
+
+            return \trim($sql . ' ' . $statement);
+        }, '');
+    }
+
+    /**
+     * Get all of the parameters attached to this statement.
+     *
+     * @return array
+     */
+    public function values()
+    {
+        return array_reduce($this->parts, function ($values, $part) {
+            if ($this->isGroup($part['condition'])) {
+                return \array_merge($values, $part['condition']->values());
+            }
+
+            return \array_merge($values, $part['values']);
+        }, []);
+    }
+
+    /**
+     * Convert the statement to a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->sql();
+    }
+
+    /**
+     * @var array
+     */
+    private $parts = [];
+
+    /**
+     * @var EasyStatement
+     */
+    private $parent;
+
+    protected function __construct(EasyStatement $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    /**
+     * Check if a condition is a sub-group.
+     *
+     * @param mixed $condition
+     *
+     * @return bool
+     */
+    protected function isGroup($condition)
+    {
+        if (false === \is_object($condition)) {
+            return false;
+        }
+
+        return $condition instanceof EasyStatement;
+    }
+
+    /**
+     * Replace a grouped placeholder with a list of placeholders.
+     *
+     * Given a count of 3, the placeholder ?* will become ?, ?, ?
+     *
+     * @param string $condition
+     * @param integer $count
+     *
+     * @return string
+     */
+    private function unpackCondition($condition, $count)
+    {
+        // Replace a grouped placeholder with an matching count of placeholders.
+        $params = '?' . \str_repeat(', ?', $count - 1);
+        return \str_replace('?*', $params, $condition);
+    }
+}

--- a/tests/EasyStatementTest.php
+++ b/tests/EasyStatementTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace ParagonIE\EasyDB\Tests;
+
+use ParagonIE\EasyDB\EasyStatement;
+use PHPUnit_Framework_TestCase as TestCase;
+use RuntimeException;
+
+/**
+ * @package ParagonIE\EasyDB\Tests
+ */
+class EasyStatementTest extends TestCase
+{
+    public function testBasicAndOr()
+    {
+        $statement = EasyStatement::open()
+            ->andWith('id = ?', 1)
+            ->andWith('last_login > ?', 'today')
+            ->orWith('last_login IS NULL');
+
+        $this->assertSql($statement, 'id = ? AND last_login > ? OR last_login IS NULL');
+        $this->assertValues($statement, [1, 'today']);
+    }
+
+    public function testLogicalIn()
+    {
+        $statement = EasyStatement::open()
+            ->andIn('role_id IN (?*)', [1, 2, 3])
+            ->orIn('user_id IN (?*)', [100]);
+
+        $this->assertSql($statement, 'role_id IN (?, ?, ?) OR user_id IN (?)');
+        $this->assertValues($statement, [1, 2, 3, 100]);
+
+        $statement = EasyStatement::open()
+            ->orIn('role_id IN (?*)', [4, 5, 6]);
+
+        $this->assertSql($statement, 'role_id IN (?, ?, ?)');
+        $this->assertValues($statement, [4, 5, 6]);
+    }
+
+    public function testGroupingWithAnd()
+    {
+        $statement = EasyStatement::open()
+            ->andWith('id = ?', 1);
+
+        $group = $statement->andGroup()
+            ->andWith('last_login > ?', 'today')
+            ->orWith('last_login IS NULL');
+
+        $this->assertSame($statement, $group->endGroup());
+
+        $this->assertSql($group, 'last_login > ? OR last_login IS NULL');
+        $this->assertSql($statement, 'id = ? AND (' . $group->sql() . ')');
+
+        $this->assertValues($statement, [1, 'today']);
+    }
+
+    public function testGroupingWithOr()
+    {
+        $statement = EasyStatement::open()
+            ->orGroup()
+                ->andWith('failed_logins > ?', 5)
+                ->andWith('last_login IS NULL')
+            ->endGroup()
+            ->orGroup()
+                ->andWith('role = ?', 'banned')
+            ->endGroup();
+
+        $this->assertSql($statement, '(failed_logins > ? AND last_login IS NULL) OR (role = ?)');
+        $this->assertValues($statement, [5, 'banned']);
+    }
+
+    public function testGroupParent()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $statement = EasyStatement::open()->endGroup();
+    }
+
+    private function assertSql(EasyStatement $statement, $expected)
+    {
+        $this->assertSame($expected, $statement->sql());
+        $this->assertSame($expected, (string) $statement);
+    }
+
+    private function assertValues(EasyStatement $statement, array $values)
+    {
+        $this->assertSame($values, $statement->values());
+    }
+}

--- a/tests/EasyStatementTest.php
+++ b/tests/EasyStatementTest.php
@@ -14,7 +14,7 @@ class EasyStatementTest extends TestCase
     public function testBasicAndOr()
     {
         $statement = EasyStatement::open()
-            ->andWith('id = ?', 1)
+            ->with('id = ?', 1)
             ->andWith('last_login > ?', 'today')
             ->orWith('last_login IS NULL');
 
@@ -25,7 +25,7 @@ class EasyStatementTest extends TestCase
     public function testLogicalIn()
     {
         $statement = EasyStatement::open()
-            ->andIn('role_id IN (?*)', [1, 2, 3])
+            ->in('role_id IN (?*)', [1, 2, 3])
             ->orIn('user_id IN (?*)', [100]);
 
         $this->assertSql($statement, 'role_id IN (?, ?, ?) OR user_id IN (?)');
@@ -41,10 +41,10 @@ class EasyStatementTest extends TestCase
     public function testGroupingWithAnd()
     {
         $statement = EasyStatement::open()
-            ->andWith('id = ?', 1);
+            ->with('id = ?', 1);
 
-        $group = $statement->andGroup()
-            ->andWith('last_login > ?', 'today')
+        $group = $statement->group()
+            ->with('last_login > ?', 'today')
             ->orWith('last_login IS NULL');
 
         $this->assertSame($statement, $group->endGroup());
@@ -59,12 +59,12 @@ class EasyStatementTest extends TestCase
     {
         $statement = EasyStatement::open()
             ->orGroup()
-                ->andWith('failed_logins > ?', 5)
+                ->with('failed_logins > ?', 5)
                 ->andWith('last_login IS NULL')
-            ->endGroup()
+            ->end()
             ->orGroup()
-                ->andWith('role = ?', 'banned')
-            ->endGroup();
+                ->with('role = ?', 'banned')
+            ->end();
 
         $this->assertSql($statement, '(failed_logins > ? AND last_login IS NULL) OR (role = ?)');
         $this->assertValues($statement, [5, 'banned']);


### PR DESCRIPTION
Dynamic queries are particularly troublesome when working outside of
traditional ORMs. Having a statement builder makes it much easier to
create conditional WHERE statements based on runtime needs.