### PR TITLE
Add script to backport to PHP 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,16 @@
     },
     "require": {
         "ext-pdo": "*"
+    },
+    "require-dev": {
+        "spatie/7to5": "^1.0"
+    },
+    "scripts": {
+        "php5ize": [
+            "php7to5 convert --overwrite --copy-all -- src/ src-php5/",
+            "php7to5 convert --overwrite --copy-all -- tests/ tests-php5/",
+            "rm -rf src && mv src-php5 src",
+            "rm -rf tests && mv tests-php5 tests"
+        ]
     }
 }


### PR DESCRIPTION
Attempting to make it easier to release 1.x versions without having to
manually backport changes.