### PR TITLE
Get engine from connection when none provided

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -43,6 +43,11 @@ class EasyDB
             \PDO::ATTR_ERRMODE,
             \PDO::ERRMODE_EXCEPTION
         );
+
+        if (empty($dbEngine)) {
+            $dbEngine = $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+        }
+
         $this->dbEngine = $dbEngine;
     }
 


### PR DESCRIPTION
The currently used database engine can be fetched from PDO if it is not
set at runtime.

Fixes #23