### PR TITLE
Add support for escaping LIKE values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
-  - '7.0'
+  - 7.0
+  - 7.1
   - hhvm
   - nightly
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+# Version 2.2.0
+
+* Added `EasyDB::escapeLikeValue()` for escaping wildcards in `LIKE` condition values.
+
+# Version 2.1.1
+
+* Fix PHP version requirement to work with HHVM.
+
 # Version 2.1.0
 
-* Import `EasyStatement` from 1.x version
+* Import `EasyStatement` from 1.x version.
 
 # Version 2.0.1 - 2016-10-18
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $statement = EasyStatement::open()
 
 if (strpos($_POST['search'], '@') !== false) {
     // Perform a username search
-    $statement->orWith('username LIKE ?', '%' . $_POST['search'] . '%');
+    $statement->orWith('username LIKE ?', '%' . $db->escapeLikeValue($_POST['search']) . '%');
 } else {
     // Perform an email search
     $statement->orWith('email = ?', $_POST['search']);

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -332,6 +332,32 @@ class EasyDB
     }
 
     /**
+     * Escape a value that will be used as a LIKE condition.
+     *
+     * Input: ("string_not%escaped")
+     * Output: "string\_not\%escaped"
+     *
+     * WARNING: This function always escapes wildcards using backslash!
+     *
+     * @param string $value
+     * @return string
+     */
+    public function escapeLikeValue(string $value): string
+    {
+        // Standard wildcards are underscore and percent sign.
+        $value = str_replace('%', '\\%', $value);
+        $value = str_replace('_', '\\_', $value);
+
+        if ($this->dbEngine === 'mssql') {
+            // MSSQL also includes character ranges.
+            $value = str_replace('[', '\\[', $value);
+            $value = str_replace(']', '\\]', $value);
+        }
+
+        return $value;
+    }
+
+    /**
      * Use with SELECT COUNT queries to determine if a record exists.
      *
      * @param string $statement

--- a/tests/EscapeLikeTest.php
+++ b/tests/EscapeLikeTest.php
@@ -1,0 +1,67 @@
+<?php
+declare (strict_types=1);
+
+namespace ParagonIE\EasyDB\Tests;
+
+use ParagonIE\EasyDB\EasyDB;
+use PDO;
+
+class EscapeLikeTest extends EasyDBTest
+{
+    public function dataValues()
+    {
+        return [
+            // input, expected
+            ['plain', 'plain'],
+            ['%single', '\\%single'],
+            ['%double%', '\\%double\\%'],
+            ['_under_score_', '\\_under\\_score\\_'],
+            ['%mix_ed', '\\%mix\\_ed'],
+            ['\\%escaped?', '\\\\%escaped?'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataValues
+     */
+    public function testEscapeLike($input, $expected)
+    {
+        // This defines sqlite, but mysql and postgres share the same rules
+        $easydb = new EasyDB($this->getMockPDO(), 'sqlite');
+
+        $output = $easydb->escapeLikeValue($input);
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function dataMSSQLValues()
+    {
+        return array_merge($this->dataValues(), [
+            // input, expected
+            ['[range]', '\\[range\\]'],
+            ['[^negated]', '\\[^negated\\]'],
+        ]);
+    }
+    /**
+     * @dataProvider dataMSSQLValues
+     */
+    public function testMSSQLEscapeLike($input, $expected)
+    {
+        $easydb = new EasyDB($this->getMockPDO(), 'mssql');
+
+        $output = $easydb->escapeLikeValue($input);
+
+        $this->assertSame($expected, $output);
+    }
+
+    private function getMockPDO(): PDO
+    {
+        $mock = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->method('setAttribute')->willReturn(true);
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
SQL defines additional wildcards for the LIKE statement:

- `_` matches a single character
- `%` matches any number of characters

In additional, [MSSQL defines two additional options][1]:

- `[ ]` matches an character range
- `[^ ]` negates a character range

A cleverly crafted value added a query, even when escaped using a
prepared statement, could cause unexpected results. Allow users to
negate these side effects by escaping all wildcards in values used for
`LIKE` statements.

[1]: https://msdn.microsoft.com/en-us/library/ms179859.aspx