### PR TITLE
Add method to build an INSERT query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.3.0
+
+* Added `EasyDB::buildInsertQuery` for building `INSERT` statements without executing.
+
 # Version 2.2.1
 
 * Adopt strict PSR-2 code style and add `phpcs` check.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ $db->insert('comments', [
 ]);
 ```
 
+#### Build an insert without executing
+
+```php
+$sql = $db->buildInsertQuery('comments', [
+    'blogpostid',
+    'userid',
+    'comment'
+]);
+
+// INSERT INTO comments (blogpostid, userid, comment) VALUES (?, ?, ?)
+
+$result = $db->q(
+    $sql,
+    $values,
+    \PDO::FETCH_BOTH,
+    true
+);
+```
+
 ### Update a row from a database table
 
 ```php

--- a/tests/InsertTest.php
+++ b/tests/InsertTest.php
@@ -78,4 +78,16 @@ class InsertTest extends
             '1'
         );
     }
+
+    /**
+     * @dataProvider GoodFactoryCreateArgument2EasyDBProvider
+     * @param callable $cb
+     */
+    public function testBuildeInsertSql(callable $cb)
+    {
+        $db = $this->EasyDBExpectedFromCallable($cb);
+        $statement = $db->buildInsertQuery('test_table', ['id', 'col1', 'col2']);
+        $expected = '/insert into .test_table. \(.id., .col1., .col2.\) VALUES \(\?, \?, \?\)/i';
+        $this->assertRegExp($expected, $statement);
+    }
 }


### PR DESCRIPTION
Allows for modifications to `INSERT` statements before execution.

For example, Postgres allows for an `INSERT ... RETURNING column`
statement to return an auto-increment primary key. The PDO method
`lastInsertId` typically does not work, nor does EasyDB expose it.

Fixes #31