### PR TITLE
Escape backslash character when escaping LIKE values

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -344,6 +344,8 @@ class EasyDB
      */
     public function escapeLikeValue(string $value): string
     {
+        // Backslash is used to escape wildcards.
+        $value = str_replace('\\', '\\\\', $value);
         // Standard wildcards are underscore and percent sign.
         $value = str_replace('%', '\\%', $value);
         $value = str_replace('_', '\\_', $value);

--- a/tests/EscapeLikeTest.php
+++ b/tests/EscapeLikeTest.php
@@ -17,7 +17,7 @@ class EscapeLikeTest extends EasyDBTest
             ['%double%', '\\%double\\%'],
             ['_under_score_', '\\_under\\_score\\_'],
             ['%mix_ed', '\\%mix\\_ed'],
-            ['\\%escaped?', '\\\\%escaped?'],
+            ['\\%escaped?', '\\\\\\%escaped?'],
         ];
     }
 


### PR DESCRIPTION
The character used to do the escaping must be taken into
account when escaping LIKE values or it can change the
meaning of a query.

In the following example, the last wildcard will not work if
`$_POST['search']` has for value `\`:
```php
$statement->orWith('username LIKE ?', '%' . $db->escapeLikeValue($_POST['search']) . '%');
```

References in RDBMS documentation:
 * MySQL [1]: "[...] you must double any \ that you use in LIKE strings."
 * MariaDB [2]: "Thus, to match an actual backslash, you sometimes need to double-escape it as '\\\\'."
 * PostgreSQL [3]: "Thus, writing a pattern that actually matches a literal backslash means writing
four backslashes in the statement."
 * SQLite [4]: "[...] a second instance of the escape character itself matches a literal
percent symbol, underscore, or a single escape character, respectively"
 * MSSQL [5]: "[...] the escape character is discarded and the character following the escape
is treated as a regular character in the pattern."

[1] https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html
[2] https://mariadb.com/kb/en/mariadb/like/#description
[3] https://www.postgresql.org/docs/8.3/static/functions-matching.html#FUNCTIONS-LIKE
[4] https://www.sqlite.org/lang_expr.html
[5] https://msdn.microsoft.com/en-us/library/ms179859.aspx#Anchor_8