### PR TITLE
Fix for reported issue with Sqlite

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -595,6 +595,7 @@ class EasyDB
      * @param string $statement SQL query without user data
      * @param mixed ...$params  Parameters
      * @return mixed
+     * @throws \TypeError
      */
     public function q(string $statement, ...$params)
     {
@@ -609,10 +610,11 @@ class EasyDB
      * @param string $statement SQL query without user data
      * @param mixed ...$params  Parameters
      * @return mixed
+     * @throws \TypeError
      */
     public function row(string $statement, ...$params)
     {
-        /** @var array $result */
+        /** @var array|int $result */
         $result = (array) $this->safeQuery($statement, $params);
         if (\is_array($result)) {
             return \array_shift($result);
@@ -626,6 +628,7 @@ class EasyDB
      * @param string $statement SQL query without user data
      * @param mixed ...$params  Parameters
      * @return mixed - If successful, a 2D array
+     * @throws \TypeError
      */
     public function run(string $statement, ...$params)
     {
@@ -644,6 +647,7 @@ class EasyDB
      * @return array|int|object
      * @throws \InvalidArgumentException
      * @throws Issues\QueryError
+     * @throws \TypeError
      */
     public function safeQuery(
         string $statement,
@@ -856,7 +860,7 @@ class EasyDB
      */
     protected function getResultsStrictTyped(\PDOStatement $stmt, int $fetchStyle = \PDO::FETCH_ASSOC)
     {
-        /** @var array|object $results */
+        /** @var array|object|bool $results */
         $results = $stmt->fetchAll($fetchStyle);
         if (\is_array($results)) {
             return (array) $results;

--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -37,6 +37,7 @@ class EasyStatement
      * @param mixed ...$values
      *
      * @return self
+     * @throws \TypeError
      */
     public function with(string $condition, ...$values): self
     {
@@ -51,6 +52,7 @@ class EasyStatement
      *
      * @return self
      * @throws \TypeError
+     * @psalm-suppress RedundantConditionGivenDocblockType
      */
     public function andWith($condition, ...$values): self
     {
@@ -90,6 +92,7 @@ class EasyStatement
      *
      * @return self
      * @throws \TypeError
+     * @psalm-suppress RedundantConditionGivenDocblockType
      */
     public function orWith($condition, ...$values): self
     {
@@ -128,6 +131,7 @@ class EasyStatement
      * @param array $values
      *
      * @return self
+     * @throws \TypeError
      */
     public function in(string $condition, array $values): self
     {
@@ -143,6 +147,7 @@ class EasyStatement
      * @param array $values
      *
      * @return self
+     * @throws \TypeError
      */
     public function andIn(string $condition, array $values): self
     {
@@ -158,6 +163,7 @@ class EasyStatement
      * @param array $values
      *
      * @return self
+     * @throws \TypeError
      */
     public function orIn(string $condition, array $values): self
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -56,9 +56,6 @@ abstract class Factory
             case 'pgsql':
                 $post_query = 'SET NAMES UNICODE';
                 break;
-            case 'sqlite':
-                $post_query = 'SET NAMES UTF8';
-                break;
         }
 
         try {


### PR DESCRIPTION
https://github.com/paragonie/easydb/pull/41#issuecomment-366485706

> From what I can tell from the sqlite site, the default charset is utf8 anyway. The only other supported option seems to be utf16, although I am not super familiar with the workings of sqlite so I could be wrong.

That appears to be the case. It doesn't seem to support anything except those two, natively, so I'm comfortable with letting the driver handle encoding.