### PR TITLE
Adds support for `TABLE_PREFIX` on the `options` property

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -71,7 +71,7 @@ class EasyDB
      * @return mixed
      */
     public function col(string $statement, int $offset = 0, ...$params)
-    {
+    {   
         return $this->column($statement, $params, $offset);
     }
 
@@ -85,7 +85,14 @@ class EasyDB
      * @return mixed
      */
     public function column(string $statement, array $params = [], int $offset = 0)
-    {
+    {   
+        if(isset($this->options['TABLE_PREFIX']))
+        {
+            $statement = str_replace('tbl_', 
+                $this->options['TABLE_PREFIX'], 
+                $statement
+            );
+        }
         $stmt = $this->pdo->prepare($statement);
         if (!$this->is1DArray($params)) {
             throw new \InvalidArgumentException(
@@ -125,6 +132,13 @@ class EasyDB
      */
     public function delete(string $table, $conditions): int
     {
+        if(isset($this->options['TABLE_PREFIX']))
+        {
+            $table = str_replace('tbl_', 
+                $this->options['TABLE_PREFIX'], 
+                $table
+            );
+        }
         if ($conditions instanceof EasyStatement) {
             return $this->deleteWhereStatement($table, $conditions);
         } elseif (\is_array($conditions)) {
@@ -248,6 +262,13 @@ class EasyDB
      */
     public function escapeIdentifier(string $string, bool $quote = true): string
     {
+        if(isset($this->options['TABLE_PREFIX']))
+        {
+            $table = str_replace('tbl_', 
+                $this->options['TABLE_PREFIX'], 
+                $string
+            );
+        }
         if (empty($string)) {
             throw new Issues\InvalidIdentifier(
                 'Invalid identifier: Must be a non-empty string.'
@@ -411,7 +432,14 @@ class EasyDB
      * @return string
      */
     public function escapeLikeValue(string $value): string
-    {
+    {   
+        if(isset($this->options['TABLE_PREFIX']))
+        {
+            $table = str_replace('tbl_', 
+                $this->options['TABLE_PREFIX'], 
+                $value
+            );
+        }
         // Backslash is used to escape wildcards.
         $value = str_replace('\\', '\\\\', $value);
         // Standard wildcards are underscore and percent sign.
@@ -763,6 +791,13 @@ class EasyDB
                 'Only one-dimensional arrays are allowed.'
             );
         }
+        if(isset($this->options['TABLE_PREFIX']))
+        {
+            $table = str_replace('tbl_', 
+                $this->options['TABLE_PREFIX'], 
+                $statement
+            );
+        }
         $stmt = $this->pdo->prepare($statement);
         $stmt->execute($params);
         if ($returnNumAffected) {
@@ -785,6 +820,13 @@ class EasyDB
         if (!$this->is1DArray($params)) {
             throw new \InvalidArgumentException(
                 'Only one-dimensional arrays are allowed.'
+            );
+        }
+        if(isset($this->options['TABLE_PREFIX']))
+        {
+            $table = str_replace('tbl_', 
+                $this->options['TABLE_PREFIX'], 
+                $statement
             );
         }
         $stmt = $this->pdo->prepare($statement);

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -793,7 +793,7 @@ class EasyDB
         }
         if(isset($this->options['TABLE_PREFIX']))
         {
-            $table = str_replace('tbl_', 
+            $statement = str_replace('tbl_', 
                 $this->options['TABLE_PREFIX'], 
                 $statement
             );
@@ -824,7 +824,7 @@ class EasyDB
         }
         if(isset($this->options['TABLE_PREFIX']))
         {
-            $table = str_replace('tbl_', 
+            $statement = str_replace('tbl_', 
                 $this->options['TABLE_PREFIX'], 
                 $statement
             );


### PR DESCRIPTION
There is almost certainly a better way to do this. 

Basically, if `TABLE_OPTIONS` is specified in the Factor's `options` constructor, EasyDB will replace every instance of `tbl_` in queries with the specified table prefix. 

