### PR TITLE
Use a valid file name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /tests/phpunit.phar
 /tests/phpunit.phar.asc
 /.editorconfig
-/phpunit.xml
+/phpunit.xml.dist


### PR DESCRIPTION
- `phpunit.xml` was renamed to `phpunit.xml.dist`.