### PR TITLE
passing on return value of callback passed to EasyDB::tryFlatTransaction()

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,21 +143,21 @@ $exists = $db->cell(
 );
 /* OR YOU CAN CALL IT THIS WAY: */
 $exists = $db->single(
-    "SELECT count(id) FROM users WHERE email = ?", 
+    "SELECT count(id) FROM users WHERE email = ?",
     array(
-        $_POST['email'] 
+        $_POST['email']
     )
 );
 ```
 
 ### Try to perform a transaction
 ```php
-$save = function (EasyDB $db) use ($userData, $query) {
+$save = function (EasyDB $db) use ($userData, $query) : int {
     $db->safeQuery($query, [$userData['userId']]);
-    \Some\Other\Package::CleanUpTable($db);
+    return \Some\Other\Package::CleanUpTable($db);
 };
 // auto starts, commits and rolls back a transaction as necessary
-$db->tryFlatTransaction($save);
+$returnedInt = $db->tryFlatTransaction($save);
 ```
 
 ### Generate dynamic query conditions

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -1069,11 +1069,11 @@ class EasyDB
      *
      * @param callable $callback
      *
-     * @return bool
+     * @return mixed
      *
      * @throws Throwable
      */
-    public function tryFlatTransaction(callable $callback): bool
+    public function tryFlatTransaction(callable $callback)
     {
         $autoStartTransaction = $this->inTransaction() === false;
 
@@ -1082,12 +1082,16 @@ class EasyDB
             $this->beginTransaction();
         }
         try {
-            /** @psalm-suppress TooManyArguments Psalm has no way of knowing this. */
-            $callback($this);
+            /**
+            * @var scalar|null|array|object|resource $out
+            */
+            $out = $callback($this);
             // If we started the transaction, we should commit here
             if ($autoStartTransaction) {
                 $this->commit();
             }
+
+            return $out;
         } catch (Throwable $e) {
             // If we started the transaction, we should cleanup here
             if ($autoStartTransaction) {
@@ -1096,8 +1100,6 @@ class EasyDB
 
             throw $e;
         }
-
-        return true;
     }
 
     /**

--- a/tests/InsertManyFlatTransactionTest.php
+++ b/tests/InsertManyFlatTransactionTest.php
@@ -18,6 +18,9 @@ class InsertManyFlatTransactionTest extends
     {
         $db = $this->EasyDBExpectedFromCallable($cb);
         $db->insertMany('irrelevant_but_valid_tablename', [['foo' => '1'], ['foo' => '2']]);
+        $expectedCount = $db->tryFlatTransaction(function (EasyDB $db) : int {
+            return (int) $db->single('SELECT COUNT(*) FROM irrelevant_but_valid_tablename');
+        });
         $callbackWillThrow = function (EasyDB $mightNotBeTheOtherDb) {
             $mightNotBeTheOtherDb->insertMany('irrelevant_but_valid_tablename', [['foo' => '3'], ['foo' => '4']]);
 
@@ -31,7 +34,7 @@ class InsertManyFlatTransactionTest extends
             // we do nothing here on purpose
         }
         $this->assertEquals(
-            $db->single('SELECT COUNT(*) FROM irrelevant_but_valid_tablename'),
+            $expectedCount,
             2
         );
     }


### PR DESCRIPTION
tweaking EasyDB::tryFlatTransaction() so that the return value of a callback passed to it can be used as the return value of the method itself, i.e. to avoid `function ($db) use (& $out) {}` as a callback.