### PR TITLE
re paragonie/easydb#85, enhance error message

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -762,7 +762,13 @@ class EasyDB
         /**
          * @var array $result
          */
-        $result = (array) $this->safeQuery($statement, $params);
+        $result = (array) $this->safeQuery(
+            $statement,
+            $params,
+            self::DEFAULT_FETCH_STYLE,
+            false,
+            true
+        );
         return $result;
     }
 
@@ -779,7 +785,13 @@ class EasyDB
         /**
          * @var array|int $result
          */
-        $result = (array) $this->safeQuery($statement, $params);
+        $result = (array) $this->safeQuery(
+            $statement,
+            $params,
+            self::DEFAULT_FETCH_STYLE,
+            false,
+            true
+        );
         if (\is_array($result)) {
             return \array_shift($result);
         }
@@ -796,7 +808,7 @@ class EasyDB
      */
     public function run(string $statement, ...$params)
     {
-        return $this->safeQuery($statement, $params);
+        return $this->safeQuery($statement, $params, self::DEFAULT_FETCH_STYLE, false, true);
     }
 
     /**
@@ -808,6 +820,7 @@ class EasyDB
      *                                   statements)
      * @param  int    $fetchStyle        PDO::FETCH_STYLE
      * @param  bool   $returnNumAffected Return the number of rows affected?
+     * @param  bool   $calledWithVariadicParams Indicates method is being invoked from variadic $params method
      * @return array|int|object
      * @throws \InvalidArgumentException
      * @throws Issues\QueryError
@@ -817,7 +830,8 @@ class EasyDB
         string $statement,
         array $params = [],
         int $fetchStyle = self::DEFAULT_FETCH_STYLE,
-        bool $returnNumAffected = false
+        bool $returnNumAffected = false,
+        bool $calledWithVariadicParams = false
     ) {
         if ($fetchStyle === self::DEFAULT_FETCH_STYLE) {
             if (isset($this->options[\PDO::ATTR_DEFAULT_FETCH_MODE])) {
@@ -838,6 +852,14 @@ class EasyDB
             return $this->getResultsStrictTyped($stmt, $fetchStyle);
         }
         if (!$this->is1DArray($params)) {
+            if ($calledWithVariadicParams) {
+                throw new \InvalidArgumentException(
+                    'Only one-dimensional arrays are allowed, please use ' .
+                    __METHOD__ .
+                    '()'
+                );
+            }
+
             throw new \InvalidArgumentException(
                 'Only one-dimensional arrays are allowed.'
             );

--- a/tests/SafeQueryTest.php
+++ b/tests/SafeQueryTest.php
@@ -4,11 +4,47 @@ declare(strict_types=1);
 namespace ParagonIE\EasyDB\Tests;
 
 use ParagonIE\EasyDB\EasyDB;
+use ParagonIE\EasyDB\Factory;
 
 class SafeQueryTest extends RunTest
 {
     protected function getResultForMethod(EasyDB $db, $statement, $offset, $params)
     {
         return $db->safeQuery($statement, $params);
+    }
+
+    /**
+     * @dataProvider goodFactoryCreateArgumentProvider
+     * @param $dsn
+     * @param null $username
+     * @param null $password
+     * @param array $options
+     */
+    public function testSafeQueryCalledWithVariadicParamsThrowsException(
+        $expectedDriver,
+        $dsn,
+        $username = null,
+        $password = null,
+        $options = []
+    ) {
+        $db = Factory::create($dsn, $username, $password, $options);
+        $args = [1, 2, 3, 4];
+        $results = $db->run('SELECT ? AS foo, ? AS bar UNION SELECT ? AS foo, ? AS bar', ...$args);
+        $this->assertInternalType('array', $results);
+
+        $expectedResult = [['foo' => 1, 'bar' => 2], ['foo' => 3, 'bar' => 4]];
+
+        foreach ($results as $i => $result) {
+            $this->assertInternalType('array', $result);
+            $this->assertEquals(array_diff_assoc($result, $expectedResult[$i]), []);
+        }
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Only one-dimensional arrays are allowed, please use ' .
+            EasyDB::class .
+            '::safeQuery()'
+        );
+        $db->run('SELECT ? AS foo, ? AS bar UNION SELECT ? AS foo, ? AS bar', $args);
     }
 }


### PR DESCRIPTION
I've added an additional parameter to change the exception message to invite users calling `$rows = $db->run('SELECT ?', [1]);` to take a look at `EasyDB::safeQuery()`.