### PR TITLE
Throw a QueryError on prepare() if query string is empty.

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -1292,9 +1292,16 @@ class EasyDB
      *
      * @param  string ...$args
      * @return \PDOStatement
+     * @throws Issues\QueryError
      */
     public function prepare(...$args): \PDOStatement
     {
+        $trimmed = trim($args[0]);
+        if (empty($trimmed)) {
+            throw new Issues\QueryError(
+                "Empty query passed to prepare()"
+            );
+        }
         return $this->pdo->prepare(...$args);
     }
 

--- a/tests/PrepareTest.php
+++ b/tests/PrepareTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace ParagonIE\EasyDB\Tests;
 
+use ParagonIE\EasyDB\Exception\QueryError;
 use PDOStatement;
 
 /**
@@ -52,6 +53,12 @@ class PrepareTest extends EasyDBWriteTest
             $queryString .= ");";
 
             $this->assertInstanceOf(PDOStatement::class, $db->prepare($queryString));
+        }
+
+        try {
+            $db->prepare("\n");
+            $this->fail("EasyDB::prepare() should be failing on empty queries.");
+        } catch (QueryError $ex) {
         }
     }
 }


### PR DESCRIPTION
See #75 