### PR TITLE
Correct incorrect type-hint

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -346,7 +346,7 @@ class EasyDB
         // Build our array
         $join = [];
         /**
-         * @var string $i
+         * @var string|int $k
          * @var string|int|bool|float|null $v
          */
         foreach ($values as $k => $v) {


### PR DESCRIPTION
1. `$i` doesn't exist
2. `$k` can be an integer as well as a string