### PR TITLE
Add fromArray() alias for connect() 

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -43,7 +43,10 @@ abstract class Factory
      */
     public static function fromArray(array $config): EasyDB {
 
-        list($dsn, $username, $password, $options) = $config;
+        $dsn      = $config[0];
+        $username = $config[1] ?? null;
+        $password = $config[2] ?? null;
+        $options  = $config[3] ?? [];
 
         $dbEngine = '';
         $post_query = null;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,6 +28,23 @@ abstract class Factory
         string $password = null,
         array $options = []
     ): EasyDB {
+        return static::fromArray([$dsn, $username, $password, $options]);
+    }
+    
+    /**
+     * Create a new EasyDB object from array of parameters
+     *
+     * @param string $dsn
+     * @param string $username
+     * @param string $password
+     * @param array $options
+     * @return \ParagonIE\EasyDB\EasyDB
+     * @throws Issues\ConstructorFailed
+     */
+    public static function fromArray(array $config): EasyDB {
+
+        list($dsn, $username, $password, $options) = $config;
+
         $dbEngine = '';
         $post_query = null;
 


### PR DESCRIPTION
As per #105, in case an exception is thrown in coonect(), database credentials are shown in the stack trace.
So an alias fromArray() is added, to put all credentials into array which will appear in the stack trace as a mere word "Array".