### PR TITLE
Removed try/catch block

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -80,26 +80,7 @@ abstract class Factory
                 break;
         }
 
-        try {
-            $pdo = new \PDO($dsn, $username, $password, $options);
-        } catch (\PDOException $e) {
-            if (\strpos((string) $e->getMessage(), 'could not find driver') !== false) {
-                throw new Issues\ConstructorFailed(
-                    'Could not create a PDO connection. Is the driver installed/enabled?'
-                );
-            }
-            
-            if (\strpos((string) $e->getMessage(), 'unknown database') !== false) {
-                throw new Issues\ConstructorFailed(
-                    'Could not create a PDO connection. Check that your database exists.'
-                );
-            }
-            
-            // Don't leak credentials directly if we can.
-            throw new Issues\ConstructorFailed(
-                'Could not create a PDO connection. Please check your username and password.'
-            );
-        }
+        $pdo = new \PDO($dsn, $username, $password, $options);
 
         if (!empty($post_query)) {
             $pdo->query($post_query);


### PR DESCRIPTION
I propose the removal of the following try/catch block.

At present all it does it redefine `PDOException`'s and masks errors. I had an error where my sqlite database wasn't found, but instead I was getting the error message:

    Could not create a PDO connection. Please check your username and password.

I don't think there's any concern about leaking credentials because in environments where this sort of exposure of information is dangerous measures such as `display_errors = off` should be employed.

Instead, let the user catch the `PDOException` and deal with it as required.

My 2 cents.