### PR TITLE
Enable psalm to detect return type of EasyDB::tryFlatTransaction()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "require-dev": {
         "phpunit/phpunit": "^6",
         "squizlabs/php_codesniffer": "^3",
-        "vimeo/psalm": "^3"
+        "vimeo/psalm": "^3",
+        "psalm/plugin-phpunit": "<1"
     },
     "scripts": {
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",

--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,13 @@
             "ParagonIE\\EasyDB\\Tests\\": "tests"
         }
     },
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^7",
-        "paragonie/corner": "^1|^2",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "paragonie/corner": "^1|^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6",

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,9 @@
     name="EasyDB static analysis tests."
     useDocblockTypes="true"
     totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config"
     errorBaseline="./psalm.baseline.xml"
 >
     <projectFiles>
@@ -12,4 +15,7 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin" />
+    </plugins>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,7 @@
     name="EasyDB static analysis tests."
     useDocblockTypes="true"
     totallyTyped="true"
+    requireVoidReturnType="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config"

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <file name="tests/InsertManyFlatTransactionTest.php" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -1124,8 +1124,10 @@ class EasyDB
         }
         try {
             /**
-            * @var string|int|bool|float|null|array|object|resource $out
-            */
+             * @var scalar|array|object|resource|null $out
+             *
+             * @psalm-var T
+             */
             $out = $callback($this);
             // If we started the transaction, we should commit here
             if ($autoStartTransaction) {

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -1102,9 +1102,15 @@ class EasyDB
      * If already inside a transaction, does not start a new one.
      * Callable should accept one parameter, i.e. function (EasyDB $db) {}
      *
+     * @template T
+     *
      * @param callable $callback
      *
+     * @psalm-param callable(EasyDB):T $callback
+     *
      * @return mixed
+     *
+     * @psalm-return T
      *
      * @throws Throwable
      */

--- a/tests/EasyDBWriteTest.php
+++ b/tests/EasyDBWriteTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace ParagonIE\EasyDB\Tests;
 
 use Exception;
+use ParagonIE\EasyDB\EasyDB;
 use ParagonIE\EasyDB\Factory;
 
 /**
@@ -17,6 +18,9 @@ abstract class EasyDBWriteTest extends EasyDBTest
     * EasyDB data provider
     * Returns an array of callables that return instances of EasyDB
     * @return array
+    *
+    * @psalm-return array<int, array{0:callable():EasyDB}>
+    *
     * @see EasyDBTest::goodFactoryCreateArgumentProvider()
     */
     public function goodFactoryCreateArgument2EasyDBProvider()
@@ -28,7 +32,7 @@ abstract class EasyDBWriteTest extends EasyDBTest
                 $password = isset($arguments[3]) ? $arguments[3] : null;
                 $options = isset($arguments[4]) ? $arguments[4] : [];
                 return [
-                    function () use ($dsn, $username, $password, $options) {
+                    function () use ($dsn, $username, $password, $options) : EasyDB {
                         $factory = Factory::create(
                             $dsn,
                             $username,

--- a/tests/InsertManyFlatTransactionTest.php
+++ b/tests/InsertManyFlatTransactionTest.php
@@ -12,6 +12,8 @@ class InsertManyFlatTransactionTest extends EasyDBWriteTest
     /**
      * @dataProvider GoodFactoryCreateArgument2EasyDBProvider
      * @param callable $cb
+     *
+     * @psalm-param callable():EasyDB $cb
      */
     public function testInsertMany(callable $cb)
     {


### PR DESCRIPTION
This has been bugging me for a while, but just came up again; adding additional docblocks to allow psalm to detect the appropriate return type based on the return type of the passed callback.

snippet:
```php
        $out = $this->db->tryFlatTransaction(
            /**
            * @return array<int, Event>
            */
            function(EasyDB $db) use ($now, $limit) : array {
```

prior to this patch, psalm will detect $out as being mixed, then report the appropriate `MixedInferredReturnType`, `MixedAssignment`, and `MixedReturnStatement` errors.

With this patch, psalm appears to detect the "correct" type of `array<int, Event>` for the assignment.

Based on:
* manually patched paragonie/easydb v2.9.0
* psalm 3.2.7

I'm not entirely sure what the minimum version of psalm would be required for end users to take advantage of this docblock change (perhaps @muglug might be able to weigh in here?)