### PR TITLE
(Sometimes) allow empty IN() statements. Ref #111

### DIFF
--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -243,6 +243,7 @@ class EasyStatement
     public function andGroup(): self
     {
         $group = new self($this);
+        $group->setEmptyInStatementsAllowed($this->allowEmptyInStatements);
 
         $this->parts[] = [
             'type' => 'AND',
@@ -262,6 +263,7 @@ class EasyStatement
     public function orGroup(): self
     {
         $group = new self($this);
+        $group->setEmptyInStatementsAllowed($this->allowEmptyInStatements);
 
         $this->parts[] = [
             'type' => 'OR',

--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -211,13 +211,6 @@ class EasyStatement
             if (!$this->allowEmptyInStatements) {
                 throw new MustBeNonEmpty();
             }
-
-            // Add a closed failure:
-            $this->parts[] = [
-                'type' => 'OR',
-                'condition' => '1 = 0',
-                'values' => []
-            ];
             return $this;
         }
         return $this->orWith($this->unpackCondition($condition, \count($values)), ...$values);

--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -214,7 +214,7 @@ class EasyStatement
 
             // Add a closed failure:
             $this->parts[] = [
-                'type' => 'AND',
+                'type' => 'OR',
                 'condition' => '1 = 0',
                 'values' => []
             ];

--- a/src/Exception/MustBeNonEmpty.php
+++ b/src/Exception/MustBeNonEmpty.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\EasyDB\Exception;
+
+use ParagonIE\Corner\CornerInterface;
+use ParagonIE\Corner\CornerTrait;
+
+/**
+ * Class MustBeNonEmpty
+ * @package ParagonIE\EasyDB\Exception
+ */
+class MustBeNonEmpty extends \Exception implements CornerInterface
+{
+    use CornerTrait;
+
+    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->supportLink = 'https://github.com/paragonie/easydb';
+        $this->helpfulMessage = "By default, arrays passed to EasyStatement's in(), orIn(), andIn() methods must
+not be empty.        
+
+If you're generating a lot of dynamic arrays and wish to allow empty arrays to
+soft-fail to an empty set, simply call setEmptyInStatementsAllowed(), like so:
+
+    -     \$stmt = EasyStatement::open()->setEmptyInStatementsAllowed();
+    +     \$stmt = EasyStatement::open()->setEmptyInStatementsAllowed(true);
+
+Note that an empty IN statement yields an empty result. If you want it to fail
+open (a.k.a. discard the IN() statement entirely), you'll need to implement
+your own application logic to handle this behavior.";
+
+
+    }
+}

--- a/tests/EasyStatementTest.php
+++ b/tests/EasyStatementTest.php
@@ -3,6 +3,7 @@
 namespace ParagonIE\EasyDB\Tests;
 
 use ParagonIE\EasyDB\EasyStatement;
+use ParagonIE\EasyDB\Exception\MustBeNonEmpty;
 use PHPUnit_Framework_TestCase as TestCase;
 use RuntimeException;
 
@@ -36,6 +37,24 @@ class EasyStatementTest extends TestCase
 
         $this->assertSql($statement, 'role_id IN (?, ?, ?)');
         $this->assertValues($statement, [4, 5, 6]);
+    }
+
+    public function testEmptyIn()
+    {
+        try {
+            $statement = EasyStatement::open()
+                ->in('role_id IN (?*)', [1, 2, 3])
+                ->orIn('user_id IN (?*)', []);
+            $this->fail("Does not throw MustBeNonEmpty by default!");
+        } catch (MustBeNonEmpty $ex) {
+            $statement = EasyStatement::open()
+                ->setEmptyInStatementsAllowed(true)
+                ->in('role_id IN (?*)', [1, 2, 3])
+                ->orIn('user_id IN (?*)', []);
+        }
+
+        $this->assertSql($statement, 'role_id IN (?, ?, ?) AND 1 = 0');
+        $this->assertValues($statement, [1, 2, 3]);
     }
 
     public function testGroupingWithAnd()

--- a/tests/EasyStatementTest.php
+++ b/tests/EasyStatementTest.php
@@ -53,7 +53,7 @@ class EasyStatementTest extends TestCase
                 ->orIn('user_id IN (?*)', []);
         }
 
-        $this->assertSql($statement, 'role_id IN (?, ?, ?) AND 1 = 0');
+        $this->assertSql($statement, 'role_id IN (?, ?, ?)');
         $this->assertValues($statement, [1, 2, 3]);
 
         $statement = EasyStatement::open()

--- a/tests/EasyStatementTest.php
+++ b/tests/EasyStatementTest.php
@@ -55,6 +55,19 @@ class EasyStatementTest extends TestCase
 
         $this->assertSql($statement, 'role_id IN (?, ?, ?) AND 1 = 0');
         $this->assertValues($statement, [1, 2, 3]);
+
+        $statement = EasyStatement::open()
+            ->setEmptyInStatementsAllowed(true)
+            ->group()
+                ->with('user_id = ?', 100)
+                ->orWith('user_id = ?', 101)
+                ->orGroup()
+                    ->in('role_id IN (?*)', [])
+                ->endGroup()
+            ->endGroup();
+
+        $this->assertSql($statement, '(user_id = ? OR user_id = ? OR (1 = 0))');
+        $this->assertValues($statement, [100, 101]);
     }
 
     public function testGroupingWithAnd()


### PR DESCRIPTION
Proposed change to tolerate empty arrays with EasyStatement. See also: #111 

Without setting this flag, it immediately throws an exception instead of erroring later in the execution of EasyStatement. The flag simply forces the query statement (which may be in a subgroup) to return FALSE.