### PR TITLE
`WHERE 1` don't work in PostgreSQL

### DIFF
--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -303,7 +303,7 @@ class EasyStatement
     public function sql(): string
     {
         if (empty($this->parts)) {
-            return '1';
+            return '1 = 1';
         }
         return (string) \array_reduce(
             $this->parts,


### PR DESCRIPTION
Change from `1` to `1 = 1` because `WHERE 1` don't work in PostgreSQL