### PR TITLE
Fix/120 unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
     - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "paragonie/corner": "^1|^2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^6|^7",
         "squizlabs/php_codesniffer": "^3",
         "vimeo/psalm": "^3",
         "psalm/plugin-phpunit": "<1"

--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6|^7",
+        "psalm/plugin-phpunit": "<1",
         "squizlabs/php_codesniffer": "^3",
-        "vimeo/psalm": "^3",
-        "psalm/plugin-phpunit": "<1"
+        "vimeo/psalm": "^3"
     },
     "scripts": {
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7",
+        "php": "^7|^8",
         "ext-pdo": "*",
         "paragonie/corner": "^1|^2"
     },

--- a/tests/EasyStatementTest.php
+++ b/tests/EasyStatementTest.php
@@ -123,7 +123,7 @@ class EasyStatementTest extends TestCase
     public function testEmpty()
     {
         $stmt = EasyStatement::open();
-        $this->assertSql($stmt, '1');
+        $this->assertSql($stmt, '1 = 1');
     }
 
     public function testPrecedence()


### PR DESCRIPTION
nightly was previously failing because it's now for php 8, it's now failing because paragonie/corner doesn't allow install on php 8.

- [x] pending paragonie/corner#3