### PR TITLE
Support custom placeholder for insert and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,21 @@ $statement = EasyStatement::open()
 echo $statement; /* (subtotal > ? AND taxes > ?) OR (cost > ? AND cancelled = 1) */
 ```
 
+### Insert and Update with custom placeholder
+```php
+$db->insert('user_auth', [
+    'user_id' => 1,
+    'timestamp' => new EasyPlaceholder('NOW()'),
+    'expired' => new EasyPlaceholder('TIMESTAMPADD(HOUR, 2, NOW())'),
+    'location' => new EasyPlaceholder("ST_GeomFromText('POINT(? ?)')", 50.4019514, 30.3926105)
+])
+
+$db->update('user_auth', [
+    'last_update' => new EasyPlaceholder('NOW()'),
+])
+```
+`EasyPlaceholder` can use in `insert()`, `insertIgnore()`, `insertOnDuplicateKeyUpdate()`, `update()`.
+
 ## What if I need PDO for something specific?
 
 ```php

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ $db->insert('user_auth', [
     'user_id' => 1,
     'timestamp' => new EasyPlaceholder('NOW()'),
     'expired' => new EasyPlaceholder('TIMESTAMPADD(HOUR, 2, NOW())'),
-    'location' => new EasyPlaceholder("ST_GeomFromText('POINT(? ?)')", 50.4019514, 30.3926105)
+    'location' => new EasyPlaceholder("ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'))", 50.4019514, 30.3926105)
 ])
 
 $db->update('user_auth', [

--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -499,7 +499,7 @@ class EasyDB
      * @param  string $table - table name
      * @param  array  $map   - associative array of which values should be assigned to each field
      *
-     * @psalm-param array<string, scalar|null> $map
+     * @psalm-param array<string, scalar|EasyPlaceholder|null> $map
      *
      * @return int
      * @throws \InvalidArgumentException
@@ -536,7 +536,7 @@ class EasyDB
      * @param string $table - table name
      * @param array  $map   - associative array of which values should be assigned to each field
      *
-     * @psalm-param array<string, scalar|null> $map
+     * @psalm-param array<string, scalar|EasyPlaceholder|null> $map
      *
      * @return int
      *
@@ -574,7 +574,7 @@ class EasyDB
      * @param array  $map   - associative array of which values should be assigned to each field
      * @param array $on_duplicate_key_update
      *
-     * @psalm-param array<string, scalar|null> $map
+     * @psalm-param array<string, scalar|EasyPlaceholder|null> $map
      * @psalm-param array<int, string> $on_duplicate_key_update
      *
      * @return int
@@ -805,7 +805,7 @@ class EasyDB
      *                                                         false for ignore,
      *                                                         array for on-duplicate-key-update
      *
-     * @psalm-param array<string, scalar|null> $map
+     * @psalm-param array<string, scalar|EasyPlaceholder|null> $map
      * @psalm-param null|false|array<int, string> $duplicates_mode
      *
      * @return array {0: string, 1: array}
@@ -828,7 +828,7 @@ class EasyDB
         $values = [];
         /**
          * @var string $key
-         * @var scalar|null $value
+         * @var scalar|EasyPlaceholder|null $value
          */
         foreach ($map as $key => $value) {
             $columns[] = $key;
@@ -840,6 +840,9 @@ class EasyDB
                 } else {
                     $placeholders[] = $value ? 'TRUE' : 'FALSE';
                 }
+            } elseif ($value instanceof EasyPlaceholder) {
+                $placeholders[] = $value->mask();
+                $values = array_merge($values, $value->values());
             } else {
                 $placeholders[] = '?';
                 $values[] = $value;
@@ -1101,7 +1104,7 @@ class EasyDB
         $pre = [];
         /**
          * @var string $i
-         * @var string|int|bool|float|null $v
+         * @var string|int|bool|float|EasyPlaceholder|null $v
          */
         foreach ($changes as $i => $v) {
             $i = $this->escapeIdentifier($i);
@@ -1109,6 +1112,9 @@ class EasyDB
                 $pre []= " {$i} = NULL";
             } elseif (\is_bool($v)) {
                 $pre []= $this->makeBooleanArgument($i, $v);
+            } elseif ($v instanceof EasyPlaceholder) {
+                $pre []= " {$i} = ".$v->mask();
+                $params = array_merge($params, $v->values());
             } else {
                 $pre []= " {$i} = ?";
                 $params[] = $v;
@@ -1174,7 +1180,7 @@ class EasyDB
         $pre = [];
         /**
          * @var string $i
-         * @var string|int|bool|float|null $v
+         * @var string|int|bool|float|EasyPlaceholder|null $v
          */
         foreach ($changes as $i => $v) {
             $i = $this->escapeIdentifier($i);
@@ -1182,6 +1188,9 @@ class EasyDB
                 $pre []= " {$i} = NULL";
             } elseif (\is_bool($v)) {
                 $pre []= $this->makeBooleanArgument($i, $v);
+            } elseif ($v instanceof EasyPlaceholder) {
+                $pre []= " {$i} = ".$v->mask();
+                $params = array_merge($params, $v->values());
             } else {
                 $pre []= " {$i} = ?";
                 $params[] = $v;

--- a/src/EasyPlaceholder.php
+++ b/src/EasyPlaceholder.php
@@ -21,17 +21,19 @@ class EasyPlaceholder
      * Use custom mask for set value in INSERT or UPDATE
      *
      * @param string $mask
-     * @param array $values
+     * @param scalar|array|null ...$values
+     *
+     * @throws MustBeNonEmpty
      */
     public function __construct(string $mask, ...$values)
     {
         $values = array_reduce($values, function ($values, $value) use (&$mask) {
-            if(!is_array($value)) {
+            if (!is_array($value)) {
                 $values []= $value;
                 return $values;
             }
             $start_pos = strpos($mask, '?*');
-            if($start_pos === false) {
+            if ($start_pos === false) {
                 throw new Issues\QueryError("Mask don't have \"?*\"");
             }
             if (\count($value) < 1) {
@@ -47,11 +49,17 @@ class EasyPlaceholder
         $this->values = $values;
     }
 
+    /**
+     * @return string
+     */
     public function mask(): string
     {
         return $this->mask;
     }
 
+    /**
+     * @return array
+     */
     public function values(): array
     {
         return $this->values;

--- a/src/EasyPlaceholder.php
+++ b/src/EasyPlaceholder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ParagonIE\EasyDB;
+
+use \ParagonIE\EasyDB\Exception as Issues;
+use ParagonIE\EasyDB\Exception\MustBeNonEmpty;
+
+/**
+ * Class EasyPlaceholder
+ *
+ * @package ParagonIE\EasyDB
+ *
+ * @example
+ */
+class EasyPlaceholder
+{
+    protected $mask;
+    protected $values;
+
+    /**
+     * Use custom mask for set value in INSERT or UPDATE
+     *
+     * @param string $mask
+     * @param array $values
+     */
+    public function __construct(string $mask, ...$values)
+    {
+        $values = array_reduce($values, function ($values, $value) use (&$mask) {
+            if(!is_array($value)) {
+                $values []= $value;
+                return $values;
+            }
+            $start_pos = strpos($mask, '?*');
+            if($start_pos === false) {
+                throw new Issues\QueryError("Mask don't have \"?*\"");
+            }
+            if (\count($value) < 1) {
+                throw new MustBeNonEmpty();
+            }
+            $mask = substr($mask, 0, $start_pos)
+                . "?"
+                . str_repeat(', ?', \count($value) - 1)
+                . substr($mask, $start_pos + 2);
+            return array_merge($values, $value);
+        }, []);
+        $this->mask = $mask;
+        $this->values = $values;
+    }
+
+    public function mask(): string
+    {
+        return $this->mask;
+    }
+
+    public function values(): array
+    {
+        return $this->values;
+    }
+
+}


### PR DESCRIPTION
When u want use some DataBase function in `insert()` and `update()` function, u can't do it.
To fix it, I added new class `EasyPlaceholder` which accept first param the placeholder and then some params for `?` and `?*`.

For example u want use `NOW()` function or something else...
```php
$db->update('user', [
    'last_active' => new EasyPlaceholder("NOW()"),
    'sum' => new EasyPlaceholder("sum + ?", 10),
    'last_data' => new EasyPlaceholder("JSON_ARRAY(?*)", [ 1, 2, 3, "YES", true ])
];
