### PR TITLE
Psalm: accept EasyPlaceholder

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -672,7 +672,7 @@ class EasyDB
      *
      * @throws InvalidArgumentException
      *
-     * @psalm-param array<string, scalar|null> $map
+     * @psalm-param array<string, scalar|EasyPlaceholder|null> $map
      *
      * @psalm-taint-source input $table
      * @psalm-taint-source input $field
@@ -804,7 +804,7 @@ class EasyDB
      * @throws EasyDBException
      * @throws QueryError
      *
-     * @psalm-param array<string, scalar|null> $map
+     * @psalm-param array<string, scalar|EasyPlaceholder|null> $map
      *
      * @psalm-taint-source input $table
      */


### PR DESCRIPTION
To avoid
>Argument 2 of ParagonIE\EasyDB\EasyDB::insertReturnId expects array<string, null|scalar>