### PR TITLE
Mark nullable parameters as nullable

### DIFF
--- a/src/EasyStatement.php
+++ b/src/EasyStatement.php
@@ -420,7 +420,7 @@ class EasyStatement
      * EasyStatement constructor.
      * @param EasyStatement|null $parent
      */
-    protected function __construct(EasyStatement $parent = null)
+    protected function __construct(?EasyStatement $parent = null)
     {
         $this->parent = $parent;
     }

--- a/src/Exception/MustBeArrayOrEasyStatement.php
+++ b/src/Exception/MustBeArrayOrEasyStatement.php
@@ -4,6 +4,7 @@ namespace ParagonIE\EasyDB\Exception;
 
 use ParagonIE\Corner\CornerInterface;
 use ParagonIE\Corner\CornerTrait;
+use Throwable;
 
 /**
  * Class MustBeArrayOrEasyStatement
@@ -13,7 +14,7 @@ class MustBeArrayOrEasyStatement extends EasyDBException
 {
     use CornerTrait;
 
-    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->supportLink = 'https://github.com/paragonie/easydb';

--- a/src/Exception/MustBeEmpty.php
+++ b/src/Exception/MustBeEmpty.php
@@ -4,12 +4,13 @@ namespace ParagonIE\EasyDB\Exception;
 
 use ParagonIE\Corner\CornerInterface;
 use ParagonIE\Corner\CornerTrait;
+use Throwable;
 
 class MustBeEmpty extends EasyDBException
 {
     use CornerTrait;
 
-    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->supportLink = 'https://github.com/paragonie/easydb';

--- a/src/Exception/MustBeNonEmpty.php
+++ b/src/Exception/MustBeNonEmpty.php
@@ -4,6 +4,7 @@ namespace ParagonIE\EasyDB\Exception;
 
 use ParagonIE\Corner\CornerInterface;
 use ParagonIE\Corner\CornerTrait;
+use Throwable;
 
 /**
  * Class MustBeNonEmpty
@@ -13,7 +14,7 @@ class MustBeNonEmpty extends EasyDBException
 {
     use CornerTrait;
 
-    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->supportLink = 'https://github.com/paragonie/easydb';
@@ -29,7 +30,5 @@ soft-fail to an empty set, simply call setEmptyInStatementsAllowed(), like so:
 Note that an empty IN statement yields an empty result. If you want it to fail
 open (a.k.a. discard the IN() statement entirely), you'll need to implement
 your own application logic to handle this behavior.";
-
-
     }
 }

--- a/src/Exception/MustBeOneDimensionalArray.php
+++ b/src/Exception/MustBeOneDimensionalArray.php
@@ -14,7 +14,7 @@ class MustBeOneDimensionalArray extends EasyDBException
 {
     use CornerTrait;
 
-    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->supportLink = 'https://github.com/paragonie/easydb#only-one-dimensional-arrays-are-allowed';

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -35,8 +35,8 @@ abstract class Factory
      */
     public static function create(
         string $dsn,
-        string $username = null,
-        string $password = null,
+        ?string $username = null,
+        ?string $password = null,
         array $options = []
     ): EasyDB {
         return static::fromArray([$dsn, $username, $password, $options]);


### PR DESCRIPTION
Not marking nullable parameters as nullable explicitly will be deprecated in PHP 8.4.
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types