### PR TITLE
Use prepare/statement also when there is no parameters

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -1046,9 +1046,10 @@ class EasyDB
         }
 
         if (empty($params)) {
-            $stmt = $this->pdo->query($statement);
+            $stmt = $this->prepare($statement);
+            $stmt->execute($params);
             if ($returnNumAffected) {
-                return (int) $stmt->rowCount();
+                return $stmt->rowCount();
             }
             return $this->getResultsStrictTyped($stmt, $fetchStyle);
         }


### PR DESCRIPTION
Hi there,
I have an incompatibly between PHP-debugbar and EasyDB. See: https://github.com/php-debugbar/php-debugbar/issues/799
This is because queries without parameters are not executed with a prepareStatement call. With the PR, I'd like to use prepare() in both case.
Thanks in advance for considering it
Note: I allow myself to remove the (int) casting that is no more needed, it's the return type of `rowCount()`, but I can set it back if you prefer