### PR TITLE
Fix csv() when using non-default fetch style

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -157,7 +157,7 @@ class EasyDB
         $results = $this->safeQuery(
             $statement,
             $params,
-            self::DEFAULT_FETCH_STYLE,
+            \PDO::FETCH_ASSOC,
             false,
             true
         );


### PR DESCRIPTION
I just found out about the `csv()` helper but I was not able to use it since we are setting the default fetch style to `PDO::FETCH_OBJ` when constructing our `EasyDB` instance.
The function is using the `EasyDB::DEFAULT_FETCH_STYLE` constant but this is falling back to the configured option passed to the constructor which might not be returning an array, thus triggering an exception when passing the value to `array_values` : https://github.com/paragonie/easydb/blob/183c5fb19afc8f6f40b0ad74388bb066033340d9/src/EasyDB.php#L171

This PR replaces the `EasyDB::DEFAULT_FETCH_STYLE` by `PDO::FETCH_ASSOC` to ensure the function works even with a custom fetch style set in the constructor.

PS. I did not know how to add a test for this, if someone can tell me how to do that I could update the PR to cover this.