### PR TITLE
Allow object return type in row()

### DIFF
--- a/src/EasyDB.php
+++ b/src/EasyDB.php
@@ -968,13 +968,13 @@ class EasyDB
      *
      * @param  string $statement SQL query without user data
      * @param  string|int|float|bool|null  ...$params Parameters
-     * @return array
+     * @return array|object
      *
      * @throws TypeError
      *
      * @psalm-taint-sink sql $statement
      */
-    public function row(string $statement, ...$params): array
+    public function row(string $statement, ...$params): array|object
     {
         /**
          * @var array|int $result
@@ -988,7 +988,7 @@ class EasyDB
         );
         if (is_array($result)) {
             $first = array_shift($result);
-            if (!is_array($first)) {
+            if (!is_array($first) && !is_object($first)) {
                 /* Do not TypeError on empty results */
                 return [];
             }


### PR DESCRIPTION
Commit 03e7400 broke the `row()` function for us since we are using `PDO::FETCH_OBJ` as our default fetch style.
This PR allows the previous behavior to work again. 