### PR TITLE
Always run mutation tests

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,9 +1,6 @@
 name: Mutation Tests
 
-on:
-  create:
-    tags:
-      - v*
+on: [push]
 
 jobs:
   psalm:


### PR DESCRIPTION
Although our other high-impact libraries are slow to mutate, easydb is pretty quick, so we should always run this.